### PR TITLE
👷 Fix build by using newer tectonic version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          tectonic-version: 0.14.1
+          tectonic-version: 0.15.0
           biber-version: 2.17
       - name: Tectonic version
         run: tectonic --version


### PR DESCRIPTION
GitHub Action rolls out ubuntu 22.40 in their runners. Tectonic 0.14.1 was using OpenSSL 1.1 and is not compatible. But tectonic 0.15 uses OpenSSL 3 which is compatible