### PR TITLE
⬆️ Upgrade `@octokit/types` to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.2.4",
-        "@octokit/types": "14.1.0",
+        "@octokit/types": "15.0.0",
         "@types/node": "24.5.1",
         "@types/semver": "7.7.1",
         "@vercel/ncc": "0.38.3",
@@ -966,9 +966,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
-      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+      "integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1092,13 +1092,13 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
-      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
+      "integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^25.1.0"
+        "@octokit/openapi-types": "^26.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
-    "@octokit/types": "14.1.0",
+    "@octokit/types": "15.0.0",
     "@types/node": "24.5.1",
     "@types/semver": "7.7.1",
     "@vercel/ncc": "0.38.3",

--- a/src/release.ts
+++ b/src/release.ts
@@ -88,7 +88,12 @@ const getLatestRelease = async (octo: GithubOktokit) => {
   }
 };
 
-const asReleaseAsset = (assets: GithubReleaseAssets): ReleaseAsset[] => {
+const asReleaseAsset = (
+  assets: readonly Pick<
+    GithubReleaseAssets[number],
+    "name" | "browser_download_url"
+  >[],
+): ReleaseAsset[] => {
   return assets.map((ghAsset) => ({
     name: ghAsset.name,
     url: ghAsset.browser_download_url,


### PR DESCRIPTION
Needed to narrow the type to the few needed fields from asset, since assets have now different fields based on the type.
